### PR TITLE
Update interface for DeputyGuardianModule

### DIFF
--- a/script/CallPause.s.sol
+++ b/script/CallPause.s.sol
@@ -16,9 +16,9 @@ contract CallPause is MultisigBuilder {
         IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](1);
 
         calls[0] = IMulticall3.Call3({
-            target: _superchainConfigAddr(),
+            target: _deputyGuardianModuleAddr(),
             allowFailure: false,
-            callData: abi.encodeCall(Pausable.pause, ("presigner"))
+            callData: abi.encodeCall(Pausable.pause, ())
         });
 
         return calls;
@@ -28,7 +28,7 @@ contract CallPause is MultisigBuilder {
         return vm.envAddress("SAFE_ADDR");
     }
 
-    function _superchainConfigAddr() internal view returns (address) {
+    function _deputyGuardianModuleAddr() internal view returns (address) {
         return vm.envAddress("TARGET_ADDR");
     }
 }

--- a/script/CallUnpause.s.sol
+++ b/script/CallUnpause.s.sol
@@ -16,7 +16,7 @@ contract CallUnpause is MultisigBuilder {
         IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](1);
 
         calls[0] = IMulticall3.Call3({
-            target: _superchainConfigAddr(),
+            target: _deputyGuardianModuleAddr(),
             allowFailure: false,
             callData: abi.encodeCall(Pausable.unpause, ())
         });
@@ -28,7 +28,7 @@ contract CallUnpause is MultisigBuilder {
         return vm.envAddress("SAFE_ADDR");
     }
 
-    function _superchainConfigAddr() internal view returns (address) {
+    function _deputyGuardianModuleAddr() internal view returns (address) {
         return vm.envAddress("TARGET_ADDR");
     }
 }

--- a/script/Pauseable.sol
+++ b/script/Pauseable.sol
@@ -2,6 +2,6 @@
 pragma solidity ^0.8.15;
 
 interface Pausable {
-    function pause(string memory _identifier) external;
+    function pause() external;
     function unpause() external;
 }


### PR DESCRIPTION
**Description**

On sepolia, and soon on mainnet, the pause call will need to be directed towards the `DeputyGuardianModule`, which has a slightly different interface for the pause call:

https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/Safe/DeputyGuardianModule.sol#L84-L94