### PR TITLE
ci: drop circleci_ip_ranges flag, migrate to circleci-repo-rpc-secrets context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
           command: forge fmt --check
 
   e2e-test:
-    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
     working_directory: /go/src/github.com/ethereum-optimism/presigner
@@ -45,7 +44,7 @@ jobs:
             make deps
             go run presigner.go \
               --chain 1 \
-              --rpc-url "https://ci-mainnet-l1.optimism.io" \
+              --rpc-url "$OP_CI_MAINNET_L1_RPC_URL" \
               --target-addr 0x95703e0982140d16f8eba6d158fccede42f04a4c \
               --safe-addr 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A \
               --safe-nonce 1000 \
@@ -77,4 +76,6 @@ workflows:
       - build
       - test
       - format
-      - e2e-test
+      - e2e-test:
+          context:
+            - circleci-repo-rpc-secrets


### PR DESCRIPTION
## Summary

Remove `circleci_ip_ranges: true` from the `e2e-test` job in `.circleci/config.yml` and migrate the hardcoded `https://ci-mainnet-l1.optimism.io` allowlisted endpoint to the org-wide `circleci-repo-rpc-secrets` context env var `OP_CI_MAINNET_L1_RPC_URL`.

Part of [W3 of ethereum-optimism/core-team#2564](https://github.com/ethereum-optimism/core-team/issues/2564). Same migration pattern as the reference PR ethereum-optimism/superchain-ops#1429.

## Per-job audit

| Job | Network-wise | Tier | Change |
|---|---|---|---|
| `e2e-test` | Runs `presigner.go --rpc-url "https://ci-mainnet-l1.optimism.io"` against the allowlisted Mainnet L1 endpoint to build/sign multisig transactions | B | Drop flag; replace the hardcoded URL with `$OP_CI_MAINNET_L1_RPC_URL`; attach `circleci-repo-rpc-secrets` context to the workflow invocation |

Other jobs (`build`, `test`, `format`) never had the flag and are untouched.

## Why this is safe

`circleci_ip_ranges: true` routes a job's egress through CircleCI's 21 static IPs at premium egress pricing. Inside OP Labs that allowlist is consumed by exactly one Traefik middleware (`ci-ip-whitelist` in `ethereum-optimism/k8s` at `kustomize/gke-bootstrap/components/traefik/bases/middleware.yaml`), gating the `ci-*.optimism.io` endpoints.

`ci-mainnet-l1.optimism.io` previously required the static-IP allowlist. The `circleci-repo-rpc-secrets` context exposes `OP_CI_MAINNET_L1_RPC_URL` pointing at a non-allowlisted equivalent reachable from any egress IP, so dropping the flag and switching to the env var preserves identical functional access without routing through the premium egress path.

## Changes

- `e2e-test`: drop `circleci_ip_ranges: true`; replace `--rpc-url "https://ci-mainnet-l1.optimism.io"` with `--rpc-url "$OP_CI_MAINNET_L1_RPC_URL"`.
- `workflows.build_test.jobs`: convert the bare-name `- e2e-test` workflow entry to job-with-context form attaching `circleci-repo-rpc-secrets`.

## Verification plan

- One full CI run on the draft. Watch `e2e-test` for 403s, timeouts, or invalid-RPC-URL errors.

## Reviewer notes

- `circleci-repo-rpc-secrets` is org-wide with no project restriction — no infra changes needed for this repo to consume it.
- After CI green, will flip from draft to ready and request review.